### PR TITLE
Refactor direccion: propiedad de la orden en vez del usuario

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -33,6 +33,18 @@ class Producto(Base):
     es_combo = Column(Boolean, default=False)
     activo = Column(Boolean, default=True)
 
+class Usuario(Base):
+    __tablename__ = "usuarios"
+    __table_args__ = {"schema": "hatsu"}
+
+    id = Column(UUID, primary_key=True, default=uuid4)
+    nombre = Column(Text)
+    telefono = Column(Text)
+    email = Column(Text)
+    fecha_registro = Column(DateTime)
+    local_id = Column(UUID, ForeignKey("hatsu.locales.id"))
+    origen = Column(Text)
+
 class Orden(Base):
     __tablename__ = "ordenes"
     __table_args__ = {"schema": "hatsu"}
@@ -44,6 +56,12 @@ class Orden(Base):
     estado = Column(Text)
     monto_total = Column(Numeric)
     medio_pago = Column(Text)
+    is_takeaway = Column(Boolean)
+    fecha_procesada = Column(DateTime)
+    fecha_entregada = Column(DateTime)
+    origen = Column(Text)
+    observaciones = Column(Text)
+    direccion = Column(Text, nullable=True)  # Asegurarnos de que la columna sea nullable
 
 class OrdenDetalle(Base):
     __tablename__ = "orden_detalle"

--- a/app/utils/console_chat.py
+++ b/app/utils/console_chat.py
@@ -149,7 +149,7 @@ async def chat_loop(agent: TestAIAgent):
                 if is_human_request:
                     # Activar intervención humana y mostrar mensaje de transición
                     await mark_conversation_for_human(session, usuario_id, canal="console")
-                    human_msg = "Tu mensaje ha sido recibido y será atendido por un operador humano pronto."
+                    human_msg = "Perfecto, en breve una persona de nuestro local continúa esta conversación."
                     print("\nBot:", human_msg)
                     
                     # Contar tokens del mensaje de transición
@@ -183,13 +183,21 @@ async def chat_loop(agent: TestAIAgent):
                     if "#ORDER:" in full_response:
                         parts = full_response.split("#ORDER:")
                         user_message = parts[0].strip()
-                        # Extract the order JSON and clean it up
+                        # Extraer el JSON de la orden y limpiarlo
                         order_json = parts[1].strip()
-                        # Remove any trailing text after the JSON object
                         if "}" in order_json:
                             order_json = order_json[:order_json.rindex("}") + 1]
+                        
+                        # Parsear el JSON de la orden para asegurar que tiene todos los campos requeridos
+                        order_data = json.loads(order_json)
+                        
                         # Procesar la orden solo si viene de la consola
-                        success, is_new_user, confirmation_message = await process_order(f"#ORDER:{order_json}", session, "console", origen="console")
+                        success, is_new_user, confirmation_message = await process_order(
+                            text=f"#ORDER:{order_json}",
+                            session=session,
+                            phone="console",
+                            origen="console"
+                        )
                         if success:
                             user_message = confirmation_message
                         else:

--- a/hatsu_schema_actualizado.sql
+++ b/hatsu_schema_actualizado.sql
@@ -52,7 +52,8 @@ CREATE TABLE IF NOT EXISTS ordenes (
     fecha_procesada TIMESTAMP,
     fecha_entregada TIMESTAMP,
     origen TEXT,
-    observaciones TEXT
+    observaciones TEXT,
+    direccion TEXT
 );
 
 -- Tabla: orden_detalle

--- a/update_schema.py
+++ b/update_schema.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+from dotenv import load_dotenv
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import text
+
+# Cargar variables de entorno
+load_dotenv()
+
+# Configuración de la base de datos
+DATABASE_URL = os.getenv("DATABASE_URL")
+if DATABASE_URL and DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
+
+async def update_schema():
+    # Crear el motor de base de datos
+    engine = create_async_engine(DATABASE_URL, echo=True)
+    
+    # Leer el archivo SQL
+    with open('hatsu_schema_actualizado.sql', 'r') as file:
+        sql_script = file.read()
+    
+    # Ejecutar el script SQL
+    async with engine.begin() as conn:
+        await conn.execute(text(sql_script))
+        await conn.commit()
+    
+    print("Schema actualizado exitosamente")
+
+if __name__ == "__main__":
+    asyncio.run(update_schema()) 


### PR DESCRIPTION
- El campo direccion ahora esta en la tabla ordenes, en vez de en la tabla de usuario
- El json #ORDER contiene ahora la direccion de entrega, en vez del json #USER_DATA
- El agente pide la direccion como un flujo mas de la toma de pedido y sugiere siempre enviarlo a la ultima direccion que el usuario pidió, si existe
- Esto significa que al agente se le pasa la direccion del usuario fijandose a que direccion se envio el ultimo pedido que hizo por delivery
- Se actualizó el prompt para toda esta logica (ya no hay logica especial para cambio de direccion vs toma de direccion)
- Se actualizó y probo console_chat y whatsapp_server